### PR TITLE
chore(fdroid): deterministic versionCode + submission materials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
         run: |
           TAG="${GITHUB_REF_NAME}"
           echo "name=${TAG#v}" >> "$GITHUB_OUTPUT"
-          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
 
       - name: Decode signing keystore
         run: echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > "${RUNNER_TEMP}/release.jks"
@@ -50,7 +49,6 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           VERSION_NAME: ${{ steps.ver.outputs.name }}
-          VERSION_CODE: ${{ steps.ver.outputs.code }}
         run: |
           chmod +x ./gradlew
           ./gradlew :app:bundleRelease :app:assembleRelease --stacktrace

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -32,16 +32,33 @@ recipe to `fdroiddata` via merge request: https://gitlab.com/fdroid/fdroiddata
 
 Things to handle for the main repo:
 
-- **Versioning:** F-Droid builds from a tag, so the **`versionCode` must be real and increasing in
-  source** for each release (the CI env override is only for Play/IzzyOnDroid APKs). Bump the
-  default `versionCode` in `app/build.gradle.kts` per release, or set it deterministically from the
-  tag in the F-Droid recipe.
+- **Versioning:** ✅ handled — `versionCode` is now derived deterministically from `versionName`
+  (`MAJOR*10000 + MINOR*100 + PATCH`, e.g. `0.1.1` → `101`) in `app/build.gradle.kts`, so it's stable
+  and increasing whether built by CI or by F-Droid from source. Just bump `versionName` per release.
+- **Unsigned release build:** ✅ handled — release signing only activates when the keystore env vars
+  are present (CI), so F-Droid's `assembleRelease` produces an unsigned APK that F-Droid then signs
+  with its own key.
 - **Bundled model blob:** `app/src/main/assets/manga_panel_detector_int8.tflite` is a prebuilt
   binary committed to the repo. It is Apache-2.0 (free) **data**, not executable code, so it is
   generally acceptable, but F-Droid reviewers may ask that it be fetched at build time or flagged.
-- **Reproducible builds** are encouraged (not required). The release signing is already isolated via
-  env vars, which helps.
 - Dependencies from JitPack (7-Zip-JBinding) and Maven are allowed as free binaries.
+
+A ready-to-submit recipe is in [`fdroid/com.chakra.comicreader.yml`](fdroid/com.chakra.comicreader.yml)
+— copy it to `metadata/com.chakra.comicreader.yml` in your `fdroiddata` fork and open the MR.
+
+## Submission materials
+
+**IzzyOnDroid request** — open an issue/RFP at https://codeberg.org/IzzyOnDroid/repo with:
+
+> **App:** Chika — Chitra Katha
+> **Package:** `com.chakra.comicreader`
+> **Source:** https://github.com/batunii/chika
+> **License:** MPL-2.0 (FOSS)
+> **Releases:** signed APKs attached to GitHub Releases (`v*` tags); fastlane metadata in
+> `fastlane/metadata/android/en-US`.
+> **Anti-features:** none — no trackers, no ads, no Google Play Services, no network access.
+> All dependencies are free-licensed (Apache-2.0 / LGPL-2.1 / OFL-1.1) from Maven Central, Google
+> Maven, and JitPack. Please track GitHub releases for updates.
 
 ## Also free: direct distribution
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,9 +14,15 @@ android {
         applicationId = "com.chakra.comicreader"
         minSdk = 26
         targetSdk = 36
-        // Overridable by CI (release workflow derives these from the git tag).
-        versionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
-        versionName = System.getenv("VERSION_NAME") ?: "0.1.0"
+        // versionName comes from the git tag in CI (VERSION_NAME), else this default.
+        // versionCode is derived deterministically from it (MAJOR*10000 + MINOR*100 + PATCH) so it
+        // is reproducible and monotonically increasing across all channels (Play, F-Droid, sideload)
+        // — F-Droid builds from source and requires a stable, increasing versionCode.
+        val appVersionName = System.getenv("VERSION_NAME") ?: "0.1.1"
+        versionName = appVersionName
+        versionCode = appVersionName.split('.').map { it.toIntOrNull() ?: 0 }.let { p ->
+            (p.getOrElse(0) { 0 } * 10000) + (p.getOrElse(1) { 0 } * 100) + p.getOrElse(2) { 0 }
+        }
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables { useSupportLibrary = true }

--- a/fdroid/com.chakra.comicreader.yml
+++ b/fdroid/com.chakra.comicreader.yml
@@ -1,0 +1,28 @@
+# F-Droid main-repo recipe TEMPLATE.
+# This file is NOT used by Chika's build. To submit Chika to the F-Droid main repo, copy this to
+# metadata/com.chakra.comicreader.yml in a fork of https://gitlab.com/fdroid/fdroiddata and open a
+# merge request. F-Droid maintainers will refine it. F-Droid builds assembleRelease (unsigned, since
+# the keystore env vars are absent) and signs the result with the F-Droid key.
+
+Categories:
+  - Reading
+License: MPL-2.0
+AuthorName: Chakra (Chalchitra Krida)
+WebSite: https://github.com/batunii/chika
+SourceCode: https://github.com/batunii/chika
+IssueTracker: https://github.com/batunii/chika/issues
+
+RepoType: git
+Repo: https://github.com/batunii/chika.git
+
+Builds:
+  - versionName: 0.1.1
+    versionCode: 101
+    commit: v0.1.1
+    gradle:
+      - yes
+
+AutoUpdateMode: Version
+UpdateCheckMode: Tags ^v[0-9.]+$
+CurrentVersion: 0.1.1
+CurrentVersionCode: 101


### PR DESCRIPTION
- versionCode is now derived from versionName (MAJOR*10000+MINOR*100+PATCH, e.g. 0.1.1 -> 101) so it's stable and increasing across CI, F-Droid (build-from-source), and sideload. Removed GITHUB_RUN_NUMBER from the release workflow.
- Add fdroid/com.chakra.comicreader.yml: a ready-to-submit fdroiddata recipe template.
- DISTRIBUTION.md: IzzyOnDroid request text + submission steps; note versioning/unsigned-release are now handled.