### PR TITLE
ci(ios): vendor TFLite podspecs to bypass the rate-limited CocoaPods CDN

### DIFF
--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -8,5 +8,11 @@ use_frameworks!
 project 'Chika.xcodeproj'
 
 target 'Chika' do
-  pod 'TensorFlowLiteSwift', '2.17.0'
+  # Podspecs are vendored (podspecs/) so pod install never touches the CocoaPods CDN —
+  # raw.githubusercontent.com rate-limits GitHub Actions runners with 429s. The binaries still
+  # come from dl.google.com (TensorFlowLiteC) and the tensorflow git repo (TensorFlowLiteSwift).
+  # TensorFlowLiteC must be listed explicitly: as a transitive dep it would otherwise be
+  # resolved through the CDN.
+  pod 'TensorFlowLiteSwift', :podspec => 'podspecs/TensorFlowLiteSwift.podspec.json'
+  pod 'TensorFlowLiteC', :podspec => 'podspecs/TensorFlowLiteC.podspec.json'
 end

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -10,17 +10,19 @@ PODS:
   - TensorFlowLiteSwift/Privacy (2.17.0)
 
 DEPENDENCIES:
-  - TensorFlowLiteSwift (= 2.17.0)
+  - TensorFlowLiteC (from `podspecs/TensorFlowLiteC.podspec.json`)
+  - TensorFlowLiteSwift (from `podspecs/TensorFlowLiteSwift.podspec.json`)
 
-SPEC REPOS:
-  trunk:
-    - TensorFlowLiteC
-    - TensorFlowLiteSwift
+EXTERNAL SOURCES:
+  TensorFlowLiteC:
+    :podspec: podspecs/TensorFlowLiteC.podspec.json
+  TensorFlowLiteSwift:
+    :podspec: podspecs/TensorFlowLiteSwift.podspec.json
 
 SPEC CHECKSUMS:
-  TensorFlowLiteC: eac6d689a8d391d1b202dc59e3d9165ba64aaf73
+  TensorFlowLiteC: 7d371a2f97670c93a8eb640958ec806556ef0fc6
   TensorFlowLiteSwift: 723fe42222815e72490c79feeff05305530de393
 
-PODFILE CHECKSUM: f559509837af6ac49804551c81b4220f9bd602f9
+PODFILE CHECKSUM: b913e494cb361d6d8fc0b9796924e03c6604be0d
 
 COCOAPODS: 1.16.2

--- a/iosApp/podspecs/TensorFlowLiteC.podspec.json
+++ b/iosApp/podspecs/TensorFlowLiteC.podspec.json
@@ -1,0 +1,62 @@
+{
+  "name": "TensorFlowLiteC",
+  "version": "2.17.0",
+  "authors": "Google Inc.",
+  "license": {
+    "type": "Apache"
+  },
+  "homepage": "https://github.com/tensorflow/tensorflow",
+  "source": {
+    "http": "https://dl.google.com/tflite-release/ios/prod/tensorflow/lite/release/ios/release/32/20240729-115310/TensorFlowLiteC/2.17.0/0c10b3543e01f547/TensorFlowLiteC-2.17.0.tar.gz"
+  },
+  "summary": "TensorFlow Lite",
+  "description": "An internal-only pod containing the TensorFlow Lite C library that the public\n`TensorFlowLiteSwift` and `TensorFlowLiteObjC` pods depend on. This pod is not\nintended to be used directly. Swift developers should use the\n`TensorFlowLiteSwift` pod and Objective-C developers should use the\n`TensorFlowLiteObjC` pod.",
+  "cocoapods_version": ">= 1.9.0",
+  "platforms": {
+    "ios": "12.0"
+  },
+  "module_name": "TensorFlowLiteC",
+  "libraries": "c++",
+  "pod_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386"
+  },
+  "user_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386"
+  },
+  "default_subspecs": "Core",
+  "subspecs": [
+    {
+      "name": "Core",
+      "vendored_frameworks": "Frameworks/TensorFlowLiteC.xcframework",
+      "resource_bundles": {
+        "TensorFlowLiteC": "Frameworks/TensorFlowLiteC.xcframework/PrivacyInfo.xcprivacy"
+      }
+    },
+    {
+      "name": "CoreML",
+      "weak_frameworks": "CoreML",
+      "dependencies": {
+        "TensorFlowLiteC/Core": [
+
+        ]
+      },
+      "vendored_frameworks": "Frameworks/TensorFlowLiteCCoreML.xcframework",
+      "resource_bundles": {
+        "TensorFlowLiteCCoreML": "Frameworks/TensorFlowLiteCCoreML.xcframework/PrivacyInfo.xcprivacy"
+      }
+    },
+    {
+      "name": "Metal",
+      "weak_frameworks": "Metal",
+      "dependencies": {
+        "TensorFlowLiteC/Core": [
+
+        ]
+      },
+      "vendored_frameworks": "Frameworks/TensorFlowLiteCMetal.xcframework",
+      "resource_bundles": {
+        "TensorFlowLiteCMetal": "Frameworks/TensorFlowLiteCMetal.xcframework/PrivacyInfo.xcprivacy"
+      }
+    }
+  ]
+}

--- a/iosApp/podspecs/TensorFlowLiteSwift.podspec.json
+++ b/iosApp/podspecs/TensorFlowLiteSwift.podspec.json
@@ -1,0 +1,106 @@
+{
+  "name": "TensorFlowLiteSwift",
+  "version": "2.17.0",
+  "authors": "Google Inc.",
+  "license": {
+    "type": "Apache"
+  },
+  "homepage": "https://github.com/tensorflow/tensorflow",
+  "source": {
+    "git": "https://github.com/tensorflow/tensorflow.git",
+    "commit": "ad6d8cc177d0c868982e39e0823d0efbfb95f04c"
+  },
+  "summary": "TensorFlow Lite for Swift",
+  "description": "TensorFlow Lite is TensorFlow's lightweight solution for Swift developers. It\nenables low-latency inference of on-device machine learning models with a\nsmall binary size and fast performance supporting hardware acceleration.",
+  "cocoapods_version": ">= 1.9.0",
+  "platforms": {
+    "ios": "12.0"
+  },
+  "swift_versions": "5.0",
+  "module_name": "TensorFlowLite",
+  "static_framework": true,
+  "pod_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386"
+  },
+  "user_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "i386"
+  },
+  "default_subspecs": "Core",
+  "subspecs": [
+    {
+      "name": "Privacy",
+      "resource_bundles": {
+        "TensorFlowLite": "tensorflow/lite/swift/PrivacyInfo.xcprivacy"
+      }
+    },
+    {
+      "name": "Core",
+      "dependencies": {
+        "TensorFlowLiteC": [
+          "2.17.0"
+        ],
+        "TensorFlowLiteSwift/Privacy": [
+          "2.17.0"
+        ]
+      },
+      "source_files": "tensorflow/lite/swift/Sources/*.swift",
+      "exclude_files": "tensorflow/lite/swift/Sources/{CoreML,Metal}Delegate.swift",
+      "testspecs": [
+        {
+          "name": "Tests",
+          "test_type": "unit",
+          "source_files": "tensorflow/lite/swift/Tests/*.swift",
+          "exclude_files": "tensorflow/lite/swift/Tests/MetalDelegateTests.swift",
+          "resources": [
+            "tensorflow/lite/testdata/add.bin",
+            "tensorflow/lite/testdata/add_quantized.bin",
+            "tensorflow/lite/testdata/multi_signatures.bin"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "CoreML",
+      "source_files": "tensorflow/lite/swift/Sources/CoreMLDelegate.swift",
+      "dependencies": {
+        "TensorFlowLiteC/CoreML": [
+          "2.17.0"
+        ],
+        "TensorFlowLiteSwift/Core": [
+          "2.17.0"
+        ],
+        "TensorFlowLiteSwift/Privacy": [
+          "2.17.0"
+        ]
+      }
+    },
+    {
+      "name": "Metal",
+      "source_files": "tensorflow/lite/swift/Sources/MetalDelegate.swift",
+      "dependencies": {
+        "TensorFlowLiteC/Metal": [
+          "2.17.0"
+        ],
+        "TensorFlowLiteSwift/Core": [
+          "2.17.0"
+        ],
+        "TensorFlowLiteSwift/Privacy": [
+          "2.17.0"
+        ]
+      },
+      "testspecs": [
+        {
+          "name": "Tests",
+          "test_type": "unit",
+          "source_files": "tensorflow/lite/swift/Tests/{Interpreter,MetalDelegate}Tests.swift",
+          "resources": [
+            "tensorflow/lite/testdata/add.bin",
+            "tensorflow/lite/testdata/add_quantized.bin",
+            "tensorflow/lite/testdata/multi_add.bin"
+          ]
+        }
+      ]
+    }
+  ],
+  "swift_version": "5.0"
+}


### PR DESCRIPTION
## Why
CI on main failed twice in a row at `pod install`: `raw.githubusercontent.com` is 429-ing CocoaPods trunk CDN fetches from GitHub Actions runner IPs (run 28986948215, including a re-run).

## What
- Commit the `TensorFlowLiteSwift` and `TensorFlowLiteC` 2.17.0 podspec JSONs under `iosApp/podspecs/`
- Reference them in the Podfile via `:podspec =>` — `TensorFlowLiteC` is listed explicitly so the transitive dep doesn't fall back to the CDN
- Regenerated `Podfile.lock` (same versions, resolved as external sources)

## Verified
Ran `xcodegen generate && pod install` locally on this branch: both pods install with **zero CDN contact** (no "Adding spec repo trunk" phase). Binaries still download from `dl.google.com` / the pinned tensorflow git commit, unchanged.