### PR TITLE
feat(reader): double-tap returns to the whole-page view

### DIFF
--- a/app/src/main/java/com/chakra/comicreader/ui/reader/ReaderScreen.kt
+++ b/app/src/main/java/com/chakra/comicreader/ui/reader/ReaderScreen.kt
@@ -142,6 +142,7 @@ fun ReaderScreen(
                 onNextPage = viewModel::nextPage,
                 onPrevPage = viewModel::previousPage,
                 onToggleChrome = { chromeVisible = !chromeVisible },
+                onShowFullPage = viewModel::showFullPage,
             )
         }
 
@@ -271,6 +272,7 @@ private fun PageViewer(
     onNextPage: () -> Unit,
     onPrevPage: () -> Unit,
     onToggleChrome: () -> Unit,
+    onShowFullPage: () -> Unit,
 ) {
     val bitmap = state.page ?: return
     val image = remember(bitmap) { bitmap.asImageBitmap() }
@@ -300,7 +302,8 @@ private fun PageViewer(
         userScale = 1f; userPanX = 0f; userPanY = 0f
     }
 
-    // Animate the view transform back to the framed default (double-tap to recenter).
+    // Animate the view transform back to the framed default (used on double-tap alongside the
+    // jump back to the whole-page slot, so a pinch zoom glides out instead of snapping).
     val resetView: () -> Unit = {
         scope.launch {
             val s0 = userScale; val x0 = userPanX; val y0 = userPanY
@@ -314,8 +317,8 @@ private fun PageViewer(
 
     // A single pointer handler so taps, double-taps, and pan/zoom never fight over the same touch.
     // Tap zones drive panel navigation (which crosses page boundaries) and chrome; one-finger drag
-    // pans the floating comic; pinch zooms; double-tap recenters. A single tap is deferred briefly so
-    // a following tap can be recognised as a double-tap.
+    // pans the floating comic; pinch zooms; double-tap jumps back to the whole-page view. A single
+    // tap is deferred briefly so a following tap can be recognised as a double-tap.
     var pendingTap by remember { mutableStateOf<Job?>(null) }
 
     Box(
@@ -368,9 +371,13 @@ private fun PageViewer(
                         val tapX = down.position.x
                         val inFlight = pendingTap
                         if (inFlight != null && inFlight.isActive) {
-                            // Second quick tap → double-tap: cancel the pending single tap and recenter.
+                            // Second quick tap → double-tap: back to the whole-page view from any
+                            // panel (mirrors the ZoomOutMap button); resetView glides the pinch
+                            // zoom out, and covers the already-on-full-page case where the slot
+                            // doesn't change.
                             inFlight.cancel()
                             pendingTap = null
+                            onShowFullPage()
                             resetView()
                         } else {
                             pendingTap = scope.launch {

--- a/iosApp/Sources/ReaderView.swift
+++ b/iosApp/Sources/ReaderView.swift
@@ -26,10 +26,9 @@ struct ReaderView: View {
     // Sentinel restoreStep meaning "land on this page's whole-page outro" (used by backward turns);
     // resolved to regions.count once the page's regions are known.
     private static let outroSlot = Int.max
-    // Android's camera motion: tween(360, FastOutSlowInEasing) between framed views, and
-    // tween(240) for the double-tap recenter. FastOutSlowIn == cubic-bezier(0.4, 0, 0.2, 1).
+    // Android's camera motion: tween(360, FastOutSlowInEasing) between framed views.
+    // FastOutSlowIn == cubic-bezier(0.4, 0, 0.2, 1).
     private static let cameraTween = Animation.timingCurve(0.4, 0, 0.2, 1, duration: 0.36)
-    private static let recenterTween = Animation.timingCurve(0.4, 0, 0.2, 1, duration: 0.24)
 
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject private var settings: ChikaSettings
@@ -259,11 +258,12 @@ struct ReaderView: View {
             Reticle(color: Chika.crimson.opacity(0.45), inset: 6, length: 16, stroke: 2).padding(6)
         } }
         // UIKit gesture layer: pinch to zoom (1×–5×), pan when zoomed, tap zones, double-tap to
-        // recenter, and a velocity flick to turn pages — all recognized simultaneously.
+        // jump back to the whole page, and a velocity flick to turn pages — all recognized
+        // simultaneously.
         .overlay {
             ReaderGestures(
                 onTap: { location, sz in tapZone(x: location.x, width: sz.width, in: loader) },
-                onDoubleTap: { withAnimation(Self.recenterTween) { resetZoom() } },
+                onDoubleTap: { showWholePage() },
                 onPinchChanged: { scale in zoom = min(max(steadyZoom * scale, 1), 5) },
                 onPinchEnded: { if zoom <= 1.01 { resetZoom() } else { steadyZoom = zoom } },
                 onPanChanged: { t in
@@ -353,7 +353,7 @@ struct ReaderView: View {
 
     // Tap zones, matching Android: left third steps back, right third steps forward (panels are
     // pre-ordered in reading direction, so this is RTL-agnostic), middle third toggles chrome. The
-    // double-tap (recenter) is disambiguated natively by the UIKit tap recognizers, so no defer.
+    // double-tap (show whole page) is disambiguated natively by the UIKit tap recognizers, so no defer.
     private func tapZone(x: CGFloat, width: CGFloat, in loader: PageLoader) {
         if x < width / 3 { advance(by: -1, in: loader) }
         else if x > width * 2 / 3 { advance(by: 1, in: loader) }


### PR DESCRIPTION
Double-tap anywhere in the reader now jumps back to the page's whole-page view (the first view of the page), no matter which panel you're on — same camera move as the show-whole-page toolbar button. If you're already on the whole page, it recenters any pinch zoom, which was the old double-tap behavior.

Implemented on both platforms so they stay in lockstep:
- **iOS**: `onDoubleTap` now calls `showWholePage()` (camera tween + zoom reset + progress persist) instead of only resetting zoom; dropped the now-unused `recenterTween`.
- **Android**: `PageViewer` gains `onShowFullPage` wired to `viewModel::showFullPage`; the double-tap branch calls it before `resetView()` so the pinch zoom animates out while the camera jumps.

Verified: `:app:compileDebugKotlin` passes locally; iOS build is covered by CI (no local Xcode at the moment).